### PR TITLE
Fix `pass-100.json` test file path in performance.md

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -16,7 +16,7 @@ unoptimized.
 ### A smallish object
 
 We test a JSON value that, while purely synthetic, is interesting. The test subject is
-[/test/files/pass-100.json](https://github.com/RedisLabsModules/redisjson/blob/master/test/files/pass-100.json),
+[/tests/files/pass-100.json](https://github.com/RedisLabsModules/redisjson/blob/master/tests/files/pass-100.json),
 who weighs in at 380 bytes and is nested. We first test SETting it, then GETting it using several
 different paths:
 


### PR DESCRIPTION
The `test` folder seems to have been renamed as `tests`.
That broke the link to the `pass-100.json` file.